### PR TITLE
Small fix over X11 info

### DIFF
--- a/02_Unix-Bash/01_unix.md
+++ b/02_Unix-Bash/01_unix.md
@@ -34,7 +34,7 @@ Unix has several fundamental differences compared with Windows:
 
 OSX *is* Unix: A version called Darwin, based on [BSD](https://en.wikipedia.org/wiki/Berkeley_Software_Distribution). It comes packaged with all the necessary tools:
 * The full suite of command-line tools in the **Terminal**
-* An X11() server for graphics
+* An X11() server for graphics (in the XQuartz package)
 * Secure shell and secure copy for working over networks 
 * The C and FORTRAN compilers (in the Xcode toolset)
 


### PR DESCRIPTION
Hi Rachel!

macOS doesn't have a X11 compatible server out of the box. The user needs to download the XQuartz package.
